### PR TITLE
Feature/graph_training

### DIFF
--- a/docs/megnet_prob_model_mwe.py
+++ b/docs/megnet_prob_model_mwe.py
@@ -44,7 +44,7 @@ def train_model():
         train_structs,
         train_targets,
         epochs=50,
-        val_structs=val_structs,
+        val_inputs=val_structs,
         val_targets=val_targets,
     )
     prob_model.save(MODEL_SAVE_DIR)

--- a/examples/formation_energies.ipynb
+++ b/examples/formation_energies.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Binary compound formation energy prediction example\n",
     "\n",
@@ -9,21 +10,22 @@
     "\n",
     "This notebook demonstrates how to create a probabilistic model for predicting\n",
     "formation energies of binary compounds with a quantified uncertainty.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "!pip install unlocknn"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import shutil\n",
     "from pathlib import Path\n",
@@ -35,13 +37,13 @@
     "from unlocknn.download import load_data\n",
     "from unlocknn.model import MEGNetProbModel\n",
     "from unlocknn.metrics import evaluate_uq_metrics\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "THIS_DIR = Path(\".\").parent\n",
     "CONFIG_FILE = THIS_DIR / \".config\"\n",
@@ -57,30 +59,24 @@
     "    for directory in [MODEL_SAVE_DIR, LOG_DIR]:\n",
     "        if directory.exists():\n",
     "            shutil.rmtree(directory)\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Data gathering\n",
     "\n",
     "Here we download binary compounds that lie on the convex hull from the Materials\n",
     "Project, then split them into training and validation subsets.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "full_df = load_data(\"binary_e_form\")\n",
-    "full_df.head()"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -151,15 +147,29 @@
        "4                  -0.905038  "
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "full_df = load_data(\"binary_e_form\")\n",
+    "full_df.head()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4217 training samples, 1055 validation samples.\n"
+     ]
+    }
+   ],
    "source": [
     "num_training = int(TRAINING_RATIO * len(full_df.index))\n",
     "train_df = full_df[:num_training]\n",
@@ -172,46 +182,36 @@
     "\n",
     "train_targets = train_df[\"formation_energy_per_atom\"]\n",
     "val_targets = val_df[\"formation_energy_per_atom\"]\n"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "4217 training samples, 1055 validation samples.\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Model creation\n",
     "\n",
     "Now we load the `MEGNet` 2019 formation energies model, then convert this to a\n",
     "probabilistic model.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "source": [
-    "meg_model = MEGNetModel.from_mvl_models(\"Eform_MP_2019\")\n"
-   ],
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "INFO:megnet.utils.models:Package-level mvl_models not included, trying temperary mvl_models downloads..\n",
       "INFO:megnet.utils.models:Model found in local mvl_models path\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:From /home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow/python/ops/array_ops.py:5043: calling gather (from tensorflow.python.ops.array_ops) with validate_indices is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
@@ -219,8 +219,8 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:From /home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow/python/ops/array_ops.py:5043: calling gather (from tensorflow.python.ops.array_ops) with validate_indices is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
@@ -228,26 +228,20 @@
      ]
     }
    ],
-   "metadata": {
-    "scrolled": true
-   }
+   "source": [
+    "meg_model = MEGNetModel.from_mvl_models(\"Eform_MP_2019\")\n"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "source": [
-    "kl_weight = BATCH_SIZE / num_training\n",
-    "\n",
-    "prob_model = MEGNetProbModel(\n",
-    "    meg_model=meg_model,\n",
-    "    num_inducing_points=NUM_INDUCING_POINTS,\n",
-    "    kl_weight=kl_weight,\n",
-    ")\n"
-   ],
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:From /home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow_probability/python/distributions/distribution.py:346: calling GaussianProcess.__init__ (from tensorflow_probability.python.distributions.gaussian_process) with jitter is deprecated and will be removed after 2021-05-10.\n",
       "Instructions for updating:\n",
@@ -255,8 +249,8 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "WARNING:tensorflow:From /home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow_probability/python/distributions/distribution.py:346: calling GaussianProcess.__init__ (from tensorflow_probability.python.distributions.gaussian_process) with jitter is deprecated and will be removed after 2021-05-10.\n",
       "Instructions for updating:\n",
@@ -266,12 +260,19 @@
      ]
     }
    ],
-   "metadata": {
-    "scrolled": true
-   }
+   "source": [
+    "kl_weight = BATCH_SIZE / num_training\n",
+    "\n",
+    "prob_model = MEGNetProbModel(\n",
+    "    meg_model=meg_model,\n",
+    "    num_inducing_points=NUM_INDUCING_POINTS,\n",
+    "    kl_weight=kl_weight,\n",
+    ")\n"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Train the uncertainty quantifier\n",
     "\n",
@@ -281,29 +282,24 @@
     "`BatchNormalization` layer (`Norm`) that feeds into it.\n",
     "\n",
     "After this initial training, we unfreeze _all_ the layers and train the full model simulateously.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "tb_callback_1 = TensorBoard(log_dir=LOG_DIR / \"vgp_training\", write_graph=False)\n",
     "tb_callback_2 = TensorBoard(log_dir=LOG_DIR / \"fine_tuning\", write_graph=False)\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "source": [
-    "%load_ext tensorboard\n",
-    "%tensorboard --logdir logs"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "text/html": [
        "\n",
@@ -326,36 +322,30 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
-   "metadata": {}
+   "source": [
+    "%load_ext tensorboard\n",
+    "%tensorboard --logdir logs"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "source": [
-    "prob_model.train(\n",
-    "    train_structs,\n",
-    "    train_targets,\n",
-    "    epochs=50,\n",
-    "    val_structs=val_structs,\n",
-    "    val_targets=val_targets,\n",
-    "    callbacks=[tb_callback_1],\n",
-    ")\n",
-    "prob_model.save(MODEL_SAVE_DIR)\n"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Epoch 1/50\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow_probability/python/distributions/gaussian_process.py:363: UserWarning: Unable to detect statically whether the number of index_points is 1. As a result, defaulting to treating the marginal GP at `index_points` as a multivariate Gaussian. This makes some methods, like `cdf` unavailable.\n",
       "  warnings.warn(\n",
@@ -370,8 +360,8 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "33/33 - 19s - loss: 2044082.0000 - val_loss: 1888069.7500\n",
       "Epoch 2/50\n",
@@ -476,8 +466,8 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow/python/keras/utils/generic_utils.py:494: CustomMaskWarning: Custom mask layers require a config and must override get_config. When loading, the custom mask layer must be passed to the custom_objects argument.\n",
       "  warnings.warn('Custom mask layers require a config and must override '\n",
@@ -485,15 +475,15 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "INFO:tensorflow:Assets written to: binary_e_form_model/nn/assets\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow/python/keras/utils/generic_utils.py:494: CustomMaskWarning: Custom mask layers require a config and must override get_config. When loading, the custom mask layer must be passed to the custom_objects argument.\n",
       "  warnings.warn('Custom mask layers require a config and must override '\n",
@@ -501,42 +491,44 @@
      ]
     }
    ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "source": [
-    "prob_model.set_frozen([\"NN\", \"VGP\"], freeze=False)\n"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
    "source": [
     "prob_model.train(\n",
     "    train_structs,\n",
     "    train_targets,\n",
     "    epochs=50,\n",
-    "    val_structs=val_structs,\n",
+    "    val_inputs=val_structs,\n",
     "    val_targets=val_targets,\n",
-    "    callbacks=[tb_callback_2],\n",
+    "    callbacks=[tb_callback_1],\n",
     ")\n",
     "prob_model.save(MODEL_SAVE_DIR)\n"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prob_model.set_frozen([\"NN\", \"VGP\"], freeze=False)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Epoch 1/50\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow_probability/python/distributions/gaussian_process.py:363: UserWarning: Unable to detect statically whether the number of index_points is 1. As a result, defaulting to treating the marginal GP at `index_points` as a multivariate Gaussian. This makes some methods, like `cdf` unavailable.\n",
       "  warnings.warn(\n",
@@ -551,8 +543,8 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "33/33 - 22s - loss: 56607.2461 - val_loss: 239531.3906\n",
       "Epoch 2/50\n",
@@ -657,8 +649,8 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow/python/keras/utils/generic_utils.py:494: CustomMaskWarning: Custom mask layers require a config and must override get_config. When loading, the custom mask layer must be passed to the custom_objects argument.\n",
       "  warnings.warn('Custom mask layers require a config and must override '\n",
@@ -666,15 +658,15 @@
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "INFO:tensorflow:Assets written to: binary_e_form_model/nn/assets\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow/python/keras/utils/generic_utils.py:494: CustomMaskWarning: Custom mask layers require a config and must override get_config. When loading, the custom mask layer must be passed to the custom_objects argument.\n",
       "  warnings.warn('Custom mask layers require a config and must override '\n",
@@ -682,59 +674,56 @@
      ]
     }
    ],
-   "metadata": {
-    "scrolled": true
-   }
+   "source": [
+    "prob_model.train(\n",
+    "    train_structs,\n",
+    "    train_targets,\n",
+    "    epochs=50,\n",
+    "    val_inputs=val_structs,\n",
+    "    val_targets=val_targets,\n",
+    "    callbacks=[tb_callback_2],\n",
+    ")\n",
+    "prob_model.save(MODEL_SAVE_DIR)\n"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Model evaluation\n",
     "\n",
     "Finally, we'll evaluate model metrics and make some sample predictions! Note that the predictions give predicted values and standard deviations. The standard deviations can then be converted to an uncertainty;\n",
     "in this example, we'll take the uncertainty as twice the standard deviation, which will give us the 95% confidence interval (see <https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule>).\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "source": [
-    "example_structs = val_structs[:10].tolist()\n",
-    "example_targets = val_targets[:10].tolist()\n",
-    "\n",
-    "predicted, stddevs = prob_model.predict(example_structs)\n",
-    "uncerts = 2 * stddevs\n"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow_probability/python/distributions/gaussian_process.py:363: UserWarning: Unable to detect statically whether the number of index_points is 1. As a result, defaulting to treating the marginal GP at `index_points` as a multivariate Gaussian. This makes some methods, like `cdf` unavailable.\n",
       "  warnings.warn(\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "example_structs = val_structs[:10].tolist()\n",
+    "example_targets = val_targets[:10].tolist()\n",
+    "\n",
+    "predicted, stddevs = prob_model.predict(example_structs)\n",
+    "uncerts = 2 * stddevs\n"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "source": [
-    "pd.DataFrame(\n",
-    "    {\n",
-    "        \"Composition\": [struct.composition.reduced_formula for struct in example_structs],\n",
-    "        \"Formation energy per atom / eV\": example_targets,\n",
-    "        \"Predicted / eV\": [\n",
-    "            f\"{pred:.2f} ± {uncert:.2f}\" for pred, uncert in zip(predicted, uncerts)\n",
-    "        ],\n",
-    "    }\n",
-    ")\n"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -839,36 +828,39 @@
        "9       HoTl3                       -0.215986   -0.19 ± 0.04"
       ]
      },
+     "execution_count": 13,
      "metadata": {},
-     "execution_count": 13
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"Composition\": [struct.composition.reduced_formula for struct in example_structs],\n",
+    "        \"Formation energy per atom / eV\": example_targets,\n",
+    "        \"Predicted / eV\": [\n",
+    "            f\"{pred:.2f} ± {uncert:.2f}\" for pred, uncert in zip(predicted, uncerts)\n",
+    "        ],\n",
+    "    }\n",
+    ")\n"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "source": [
-    "val_metrics = evaluate_uq_metrics(prob_model, val_structs, val_targets)\n",
-    "train_metrics = evaluate_uq_metrics(prob_model, train_structs, train_targets)\n",
-    "\n",
-    "print(\"Validation metrics:\")\n",
-    "pprint(val_metrics)\n",
-    "print(\"Training metrics:\")\n",
-    "pprint(train_metrics)\n"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "/home/awsm/anaconda3/envs/unlockNN/lib/python3.8/site-packages/tensorflow_probability/python/distributions/gaussian_process.py:363: UserWarning: Unable to detect statically whether the number of index_points is 1. As a result, defaulting to treating the marginal GP at `index_points` as a multivariate Gaussian. This makes some methods, like `cdf` unavailable.\n",
       "  warnings.warn(\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Validation metrics:\n",
       "{'mae': 0.04725769517605442,\n",
@@ -887,7 +879,15 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "val_metrics = evaluate_uq_metrics(prob_model, val_structs, val_targets)\n",
+    "train_metrics = evaluate_uq_metrics(prob_model, train_structs, train_targets)\n",
+    "\n",
+    "print(\"Validation metrics:\")\n",
+    "pprint(val_metrics)\n",
+    "print(\"Training metrics:\")\n",
+    "pprint(train_metrics)\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR enables training and inference using graph inputs to the model. Although a powerful addition (reducing on the fly computation time), the change is relatively straightforwards, as it just involves skipping the structure -> graph conversion step. Tests have been updated to check that graph inputs also function correctly.