### PR TITLE
Journal reference to arXiv preprint

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -194,21 +194,18 @@
   file = {/home/awsm/Zotero/storage/DEJUW4IW/Schütt et al. - 2018 - SchNet – A deep learning architecture for molecule.pdf}
 }
 
-@online{tranMethodsComparingUncertainty2020,
-  ids = {tranMethodsComparingUncertainty2020a},
-  title = {Methods for Comparing Uncertainty Quantifications for Material Property Predictions},
-  author = {Tran, Kevin and Neiswanger, Willie and Yoon, Junwoong and Zhang, Qingyang and Xing, Eric and Ulissi, Zachary W.},
-  date = {2020-02-20},
-  eprint = {1912.10066},
-  eprinttype = {arxiv},
-  primaryclass = {cond-mat, physics:physics},
-  publisher = {{IOP Publishing}},
-  url = {http://arxiv.org/abs/1912.10066},
-  urldate = {2020-09-20},
-  abstract = {Data science and informatics tools have been proliferating recently within the computational materials science and catalysis fields. This proliferation has spurned the creation of various frameworks for automated materials screening, discovery, and design. Underpinning these frameworks are surrogate models with uncertainty estimates on their predictions. These uncertainty estimates are instrumental for determining which materials to screen next, but the computational catalysis field does not yet have a standard procedure for judging the quality of such uncertainty estimates. Here we present a suite of figures and performance metrics derived from the machine learning community that can be used to judge the quality of such uncertainty estimates. This suite probes the accuracy, calibration, and sharpness of a model quantitatively. We then show a case study where we judge various methods for predicting density-functional-theory-calculated adsorption energies. Of the methods studied here, we find that the best performer is a model where a convolutional neural network is used to supply features to a Gaussian process regressor, which then makes predictions of adsorption energies along with corresponding uncertainty estimates.},
-  archiveprefix = {arXiv},
-  keywords = {Condensed Matter - Materials Science,Physics - Computational Physics},
-  file = {/home/awsm/Zotero/storage/4I3UMCUN/Tran et al. - 2020 - Methods for comparing uncertainty quantifications .pdf}
+@article{tranMethodsComparingUncertainty2020,
+	doi = {10.1088/2632-2153/ab7e1a},
+	url = {https://doi.org/10.1088/2632-2153/ab7e1a},
+	year = 2020,
+	month = {may},
+	publisher = {{IOP} Publishing},
+	volume = {1},
+	number = {2},
+	pages = {025006},
+	author = {Kevin Tran and Willie Neiswanger and Junwoong Yoon and Qingyang Zhang and Eric Xing and Zachary W Ulissi},
+	title = {Methods for comparing uncertainty quantifications for material property predictions},
+	journal = {Machine Learning: Science and Technology}
 }
 
 @article{xieCrystalGraphConvolutional2018,


### PR DESCRIPTION
Related to [JOSS submission](https://github.com/openjournals/joss-reviews/issues/3700).

I think this might be the correct reference for Tran et al. (2020)? If not, let's keep the arXiv reference as is.